### PR TITLE
feat: add info view and URL endpoint for Saleor plugin

### DIFF
--- a/platform_plugin_saleor/urls.py
+++ b/platform_plugin_saleor/urls.py
@@ -1,10 +1,10 @@
 """
 URLs for platform_plugin_saleor.
 """
-from django.urls import re_path  # pylint: disable=unused-import
-from django.views.generic import TemplateView  # pylint: disable=unused-import
+from django.urls import path
+
+from platform_plugin_saleor import views
 
 urlpatterns = [
-    # TODO: Fill in URL patterns and views here.
-    # re_path(r'', TemplateView.as_view(template_name="platform_plugin_saleor/base.html")),
+    path('saleor-info/', views.info_view, name='saleor-info'),
 ]

--- a/platform_plugin_saleor/views.py
+++ b/platform_plugin_saleor/views.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, check_output
 
 from django.http import JsonResponse
 
-import platform_plugin_saleor
+from platform_plugin_saleor import __version__ as plugin_version
 
 
 def info_view(request):
@@ -20,9 +20,11 @@ def info_view(request):
         git_data = git_data.decode().rstrip('\r\n')
     except CalledProcessError:
         git_data = ""
+
     response_data = {
-        "version": platform_plugin_saleor.__version__,
+        "version": plugin_version,
         "name": "platform-plugin-saleor",
-        "git": git_data
+        "git": git_data,
     }
+
     return JsonResponse(response_data)

--- a/platform_plugin_saleor/views.py
+++ b/platform_plugin_saleor/views.py
@@ -1,0 +1,28 @@
+"""Generic views for the platform plugin saleor."""
+
+from os.path import dirname, realpath
+from subprocess import CalledProcessError, check_output
+
+from django.http import JsonResponse
+
+import platform_plugin_saleor
+
+
+def info_view(request):
+    """
+    Provide basic information about the plugin.
+
+    This view returns a JSON response with the version of the plugin and the git commit hash.
+    """
+    try:
+        working_dir = dirname(realpath(__file__))
+        git_data = check_output(["git", "rev-parse", "HEAD"], cwd=working_dir)
+        git_data = git_data.decode().rstrip('\r\n')
+    except CalledProcessError:
+        git_data = ""
+    response_data = {
+        "version": platform_plugin_saleor.__version__,
+        "name": "platform-plugin-saleor",
+        "git": git_data
+    }
+    return JsonResponse(response_data)


### PR DESCRIPTION
## Description

This pull request introduces a new view and URL pattern to the `platform_plugin_saleor` Django plugin. The new endpoint provides information about the current plugin installation, including its version and the associated commit SHA, as illustrated in the image below:

![image](https://github.com/user-attachments/assets/f51b309a-21dc-402d-b024-17295cb7b72c)

## How to Test

1. Navigate to your `edxapp` `/mnt` folder and clone the `platform-plugin-saleor` repository.
2. With your LMS application running, install the plugin by executing:
   ```bash
   docker exec -it tutor_dev-lms-1 bash 
   pip install -e /mnt/platform-plugin-saleor
   ```
3. Restart the LMS container to apply the changes.
4. Visit the following endpoint to verify the plugin info:  
   [http://local.overhang.io:8000/saleor/saleor-info/](http://local.overhang.io:8000/saleor/saleor-info/)
