### PR TITLE
feat: add authentication view

### DIFF
--- a/platform_plugin_saleor/saleor_client/client.py
+++ b/platform_plugin_saleor/saleor_client/client.py
@@ -20,6 +20,7 @@ from platform_plugin_saleor.saleor_client.mutations import (
     CREATE_COURSE_PRODUCT,
     CREATE_PRODUCT_ATTRIBUTES,
     CREATE_PRODUCT_TYPE,
+    CREATE_TOKEN,
 )
 from platform_plugin_saleor.saleor_client.queries import (
     GET_PRODUCT_ATTRIBUTES,
@@ -320,3 +321,13 @@ class SaleorApiClient:
             }
         }
         return self.execute(ACCOUNT_REGISTER, variables)
+
+    def create_token(self, email: str, password: str) -> dict:
+        """
+        TO-DO
+        """
+        variables = {
+            "email": email,
+            "password": password
+        }
+        return self.execute(CREATE_TOKEN, variables)

--- a/platform_plugin_saleor/saleor_client/mutations.py
+++ b/platform_plugin_saleor/saleor_client/mutations.py
@@ -84,3 +84,14 @@ mutation attachCustomer(
     }
 }
 """
+
+CREATE_TOKEN = """
+mutation createToken(
+    $email: String!, $password: String!
+) {
+    tokenCreate(email: $email, password: $password) {
+        token
+        errors { code, field, message }
+    }
+}
+"""

--- a/platform_plugin_saleor/services/urls.py
+++ b/platform_plugin_saleor/services/urls.py
@@ -3,10 +3,11 @@ TO-DO
 """
 from django.urls import path
 
-from platform_plugin_saleor.services.views import checkout
+from platform_plugin_saleor.services import views
 
 app_name = "platform_plugin_saleor"
 
 urlpatterns = [
-    path("checkout/", checkout, name="checkout"),
+    path("checkout/", views.checkout, name="checkout"),
+    path("authenticate/", views.authenticate, name="authenticate"),
 ]

--- a/platform_plugin_saleor/services/views.py
+++ b/platform_plugin_saleor/services/views.py
@@ -1,10 +1,17 @@
 """
 TO-DO
 """
-from django.http import Http404
+from django.conf import settings
+from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 
-from platform_plugin_saleor.services.helpers import create_user_checkout, get_or_create_saleor_user, get_product_variant
+from platform_plugin_saleor.services.helpers import (
+    create_user_checkout,
+    generate_password,
+    get_or_create_saleor_user,
+    get_product_variant,
+    get_saleor_api_client_instance,
+)
 
 
 def checkout(request):
@@ -21,6 +28,30 @@ def checkout(request):
     checkout_response = create_user_checkout(saleor_user=saleor_user, product_variants=[product_variant])
 
     # Hard coded value, this will be replace after defining the openedx storefront implementation.
-    response = redirect(f"http://saleor-storefront.local.overhang.io:18020/checkout?checkout={checkout_response['id']}")
+    response = redirect(f"http://local.overhang.io:18055/checkout?checkout={checkout_response['id']}")
+
+    return response
+
+
+def authenticate(request):
+    """
+    TO-DO
+    """
+    user = request.user
+    client = get_saleor_api_client_instance()
+
+    token = client.create_token(
+        email=user.email,
+        password=generate_password(user),
+    )["tokenCreate"]["token"]
+
+    response = HttpResponse()
+    response.set_cookie("openedxSaleorToken", token, domain=settings.SESSION_COOKIE_DOMAIN)
+
+    next_url = request.GET.get('next')
+
+    if next_url:
+        response['Location'] = next_url
+        response.status_code = 302
 
     return response


### PR DESCRIPTION
##  Description
this adds a new view that sets the authentication cookie 

## How to test
1. Go to http://local.overhang.io:8000/saleor/services/authenticate/
2. Check the `openedxSaleorToken` cookie
3. Check the value in https://jwt.io/

